### PR TITLE
Hermes Agent 用 Proxmox VM を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,18 @@ export TF_VAR_gateway="192.168.1.1"
 ### Hermes Agent プロビジョニング
 
 `ansible/setup-hermes.yml` は NousResearch/hermes-agent を標準 VM に導入する。
-API キーは環境変数ではなく `--extra-vars` で渡す（ansible-vault 化は将来 TODO）。
+playbook は VM 上の `/etc/hermes-agent/.env` に upstream の `.env.example` をシード
+（既存ファイルは上書きしない）するのみで、API キーの埋め込みは行わない。
+デプロイ後に運用者が SSH で `.env` を編集するか、VM 内で `hermes setup` / `hermes config set`
+を使って設定し、`sudo systemctl restart hermes-agent` する。
 
 ```bash
-ansible-playbook -i ansible/inventory.yml ansible/setup-hermes.yml \
-  --extra-vars "openrouter_api_key=XXX anthropic_api_key=YYY openai_api_key=ZZZ elevenlabs_api_key=WWW"
+# 1. VM を作成（terraform apply 済み前提）
+ansible-playbook -i ansible/inventory.yml ansible/setup-hermes.yml
+
+# 2. API キーを投入して再起動
+ssh -J ss debian@"$TF_VAR_hermes_agent_ip" \
+  'sudo -u hermes editor /etc/hermes-agent/.env && sudo systemctl restart hermes-agent'
 ```
+
+ansible-vault / SOPS での秘密管理化は TODO。

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ export TF_VAR_api_token_secret="your-proxmox-api-token-secret"
 ```bash
 export TF_VAR_master_ip="192.168.1.100"
 export TF_VAR_worker_ips='["192.168.1.101", "192.168.1.102", "192.168.1.103"]'
+export TF_VAR_hermes_agent_ip="192.168.1.110"
 export TF_VAR_network_prefix="24"
 export TF_VAR_gateway="192.168.1.1"
+```
+
+### Hermes Agent プロビジョニング
+
+`ansible/setup-hermes.yml` は NousResearch/hermes-agent を標準 VM に導入する。
+API キーは環境変数ではなく `--extra-vars` で渡す（ansible-vault 化は将来 TODO）。
+
+```bash
+ansible-playbook -i ansible/inventory.yml ansible/setup-hermes.yml \
+  --extra-vars "openrouter_api_key=XXX anthropic_api_key=YYY openai_api_key=ZZZ elevenlabs_api_key=WWW"
 ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ export TF_VAR_gateway="192.168.1.1"
 ### Hermes Agent プロビジョニング
 
 `ansible/setup-hermes.yml` は NousResearch/hermes-agent を標準 VM に導入する。
+共通 OS baseline (timezone / NTP / unattended-upgrades / 共通 apt パッケージ /
+Python 3.11 アサート) は `ansible/base.yml` に切り出されており、本 playbook が
+`import_playbook` で先に呼ぶ。
 playbook は VM 上の `/etc/hermes-agent/.env` に upstream の `.env.example` をシード
 （既存ファイルは上書きしない）するのみで、API キーの埋め込みは行わない。
 デプロイ後に運用者が SSH で `.env` を編集するか、VM 内で `hermes setup` / `hermes config set`
@@ -51,4 +54,34 @@ ssh -J ss debian@"$TF_VAR_hermes_agent_ip" \
   'sudo -u hermes editor /etc/hermes-agent/.env && sudo systemctl restart hermes-agent'
 ```
 
-ansible-vault / SOPS での秘密管理化は TODO。
+秘密管理は SOPS+age への移行が ToBe (`hermes-agent` repo の
+`docs/standards/secrets-management.md` 参照)、現状は手動投入が暫定措置。
+
+### MCP サーバプロビジョニング
+
+`ansible/setup-mcp-servers.yml` は Hermes VM 上に MCP server 群を `uv_python_service`
+role でデプロイする。各 MCP server は localhost (`127.0.0.1`) bind の HTTP 常駐
+サービスとして展開される。設計と運用標準は `hermes-agent` repo の
+`docs/plans/google-integration.md` および `docs/standards/*.md` を参照。
+
+```bash
+# 1. base.yml + Hermes 本体が既に流れていること
+ansible-playbook -i ansible/inventory.yml ansible/setup-hermes.yml
+
+# 2. MCP server 群をデプロイ
+ansible-playbook -i ansible/inventory.yml ansible/setup-mcp-servers.yml
+
+# 3. /etc/<service>/.env に OAuth client credentials を投入 (現状は手動、ToBe は SOPS)
+ssh -J ss debian@"$TF_VAR_hermes_agent_ip" \
+  'sudo -u gwmcp editor /etc/google-workspace-mcp/.env'
+ssh -J ss debian@"$TF_VAR_hermes_agent_ip" \
+  'sudo systemctl restart google-workspace-mcp'
+
+# 4. 初回 OAuth は SSH port forward + Hermes / workspace-cli から発火
+ssh -L 8080:127.0.0.1:8080 -J ss debian@"$TF_VAR_hermes_agent_ip"
+# ブラウザで Google 承認 (詳細は hermes-agent の docs/plans/google-integration.md)
+```
+
+新しい MCP server を追加する時は `ansible/setup-mcp-servers.yml` の
+`mcp_servers` リストに 1 エントリ追加し、`hermes-agent` repo の
+`docs/standards/port-allocation.md` から空き port を割当てる。

--- a/ansible/base.yml
+++ b/ansible/base.yml
@@ -1,0 +1,81 @@
+---
+# OS baseline shared by every play targeting the hermes-agent VM.
+# Imported by setup-hermes.yml and setup-mcp-servers.yml.
+# Idempotent — running this twice is a no-op.
+- name: Apply VM-wide OS baseline (timezone / NTP / auto-upgrades / common packages)
+  hosts: hermes-agent
+  remote_user: debian
+  become: yes
+
+  vars:
+    system_timezone: Asia/Tokyo
+    required_python_version: "3.11"
+
+  tasks:
+    - name: Read current timezone
+      ansible.builtin.command: timedatectl show -p Timezone --value
+      register: current_timezone
+      changed_when: false
+
+    - name: Set system timezone
+      ansible.builtin.command: "timedatectl set-timezone {{ system_timezone }}"
+      when: current_timezone.stdout != system_timezone
+
+    - name: Ensure systemd-timesyncd (NTP) is enabled and running
+      ansible.builtin.systemd_service:
+        name: systemd-timesyncd
+        enabled: yes
+        state: started
+
+    - name: Install unattended-upgrades
+      ansible.builtin.apt:
+        name:
+          - unattended-upgrades
+          - apt-listchanges
+        state: present
+        update_cache: yes
+
+    - name: Enable automatic package list refresh and security upgrades
+      ansible.builtin.copy:
+        dest: /etc/apt/apt.conf.d/20auto-upgrades
+        mode: "0644"
+        content: |
+          APT::Periodic::Update-Package-Lists "1";
+          APT::Periodic::Unattended-Upgrade "1";
+          APT::Periodic::AutocleanInterval "7";
+      notify: Reload unattended-upgrades
+
+    # Common packages required by both Hermes and uv-Python services.
+    # Per-service additional packages stay in their own playbook.
+    - name: Install common base packages
+      ansible.builtin.apt:
+        name:
+          - python3
+          - python3-venv
+          - python3-dev
+          - git
+          - curl
+          - ca-certificates
+          - build-essential
+          - libssl-dev
+          - libffi-dev
+          - acl
+        state: present
+        update_cache: yes
+
+    - name: Check python3 version
+      ansible.builtin.command: python3 --version
+      register: python_version_check
+      changed_when: false
+
+    - name: Assert python3 matches required version
+      ansible.builtin.assert:
+        that:
+          - python_version_check.stdout is match('^Python ' + (required_python_version | regex_escape) + '(\\.|$)')
+        fail_msg: "Expected Python {{ required_python_version }}, got: {{ python_version_check.stdout }}"
+
+  handlers:
+    - name: Reload unattended-upgrades
+      ansible.builtin.systemd_service:
+        name: unattended-upgrades
+        state: restarted

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -15,3 +15,10 @@ k8s-workers:
       ansible_host:  "{{ (lookup('env','TF_VAR_worker_ips') | from_json)[1] }}"
       ansible_user: debian
       ansible_ssh_private_key_file: ~/.ssh/id_ed25519_k8s
+
+hermes-agent:
+  hosts:
+    hermes-agent:
+      ansible_host: "{{ lookup('env','TF_VAR_hermes_agent_ip') }}"
+      ansible_user: debian
+      ansible_ssh_private_key_file: ~/.ssh/id_ed25519_k8s

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -22,3 +22,4 @@ hermes-agent:
       ansible_host: "{{ lookup('env','TF_VAR_hermes_agent_ip') }}"
       ansible_user: debian
       ansible_ssh_private_key_file: ~/.ssh/id_ed25519_k8s
+      ansible_ssh_common_args: "-o ProxyJump=ss -o StrictHostKeyChecking=accept-new"

--- a/ansible/roles/uv_python_service/README.md
+++ b/ansible/roles/uv_python_service/README.md
@@ -1,0 +1,67 @@
+# Role: `uv_python_service`
+
+Deploy a `uv`-managed Python application as a hardened systemd service. Designed
+for MCP servers and similar long-lived Python daemons on the `hermes-agent` VM.
+
+The role contract is documented in
+`docs/standards/ansible-role-boundaries.md` (in the `hermes-agent` repository).
+The systemd hardening flags it applies are in
+`docs/standards/systemd-hardening.md`.
+
+## Required parameters
+
+| Variable | Example |
+|---|---|
+| `service_name` | `google-workspace-mcp` |
+| `service_user` | `gwmcp` |
+| `service_home` | `/opt/google-workspace-mcp` |
+| `git_repo` | `https://github.com/taylorwilsdon/google_workspace_mcp.git` |
+| `git_version` | `v1.20.0` (must follow `docs/standards/upstream-pinning.md`) |
+| `exec_start` | `{{ service_venv_dir }}/bin/python {{ service_app_dir }}/main.py --transport streamable-http --tools calendar tasks` |
+| `read_write_paths` | `["/opt/google-workspace-mcp", "/var/lib/google-workspace-mcp"]` |
+
+## Optional parameters
+
+| Variable | Default | Notes |
+|---|---|---|
+| `python_version` | `"3.11"` | passed to `uv venv --python` |
+| `install_command` | `'uv pip install -e "."'` | run inside venv |
+| `state_dir` | `/var/lib/{{ service_name }}` | created with mode 0700 |
+| `env_dir` | `/etc/{{ service_name }}` | created with mode 0750 |
+| `hardening_profile` | `python-mcp-server` | also: `python-agent-runtime` (no extras beyond baseline) |
+| `restart_policy` | `on-failure` | systemd Restart= |
+| `restart_sec` | `10` | systemd RestartSec= |
+| `service_description` | `"{{ service_name }} (uv-managed Python service)"` | unit Description= |
+| `extra_environment` | `{}` | dict of `Environment=` entries on the unit |
+| `after_targets` | `["network-online.target"]` | systemd After= |
+| `wants_targets` | `["network-online.target"]` | systemd Wants= |
+
+## Example call
+
+```yaml
+- name: Provision Google Workspace MCP
+  ansible.builtin.include_role:
+    name: uv_python_service
+  vars:
+    service_name: google-workspace-mcp
+    service_user: gwmcp
+    service_home: /opt/google-workspace-mcp
+    git_repo: https://github.com/taylorwilsdon/google_workspace_mcp.git
+    git_version: v1.20.0
+    exec_start: >-
+      /opt/google-workspace-mcp/app/venv/bin/python
+      /opt/google-workspace-mcp/app/main.py
+      --transport streamable-http
+      --tools calendar tasks
+    read_write_paths:
+      - /opt/google-workspace-mcp
+      - /var/lib/google-workspace-mcp
+    extra_environment:
+      WORKSPACE_MCP_HOST: "127.0.0.1"
+      WORKSPACE_MCP_PORT: "8080"
+      GOOGLE_MCP_CREDENTIALS_DIR: "/var/lib/google-workspace-mcp/credentials"
+```
+
+Secrets in the unit's `EnvironmentFile=` (`/etc/{{ service_name }}/.env`) are
+populated separately. Today this is manual; the ToBe is SOPS-decrypted templating
+per `docs/standards/secrets-management.md`.

--- a/ansible/roles/uv_python_service/defaults/main.yml
+++ b/ansible/roles/uv_python_service/defaults/main.yml
@@ -1,0 +1,33 @@
+---
+# Defaults for the uv_python_service role.
+# See docs/standards/ansible-role-boundaries.md (in hermes-agent repo) for the
+# parameter contract and which values must be set by the caller vs left default.
+
+# --- Required (no sensible default; caller must set) ---
+# service_name:        e.g. "google-workspace-mcp"
+# service_user:        e.g. "gwmcp"
+# service_home:        e.g. "/opt/google-workspace-mcp"
+# git_repo:            upstream repo URL
+# git_version:         tag / SHA (must follow docs/standards/upstream-pinning.md)
+# exec_start:          systemd ExecStart= value (full command line)
+# read_write_paths:    list of paths the unit may write to
+
+# --- Optional (overridable) ---
+python_version: "3.11"
+install_command: 'uv pip install -e "."'
+state_dir: "/var/lib/{{ service_name }}"
+env_dir: "/etc/{{ service_name }}"
+hardening_profile: "python-mcp-server"   # see docs/standards/systemd-hardening.md
+restart_policy: "on-failure"
+restart_sec: 10
+service_description: "{{ service_name }} (uv-managed Python service)"
+extra_environment: {}                    # dict of Environment= entries on the unit
+after_targets: ["network-online.target"]
+wants_targets: ["network-online.target"]
+
+# Computed paths (do not override unless you know why)
+service_app_dir: "{{ service_home }}/app"
+service_venv_dir: "{{ service_app_dir }}/venv"
+service_uv_install_dir: "{{ service_home }}/.local/bin"
+service_uv_bin: "{{ service_uv_install_dir }}/uv"
+service_env_file: "{{ env_dir }}/.env"

--- a/ansible/roles/uv_python_service/handlers/main.yml
+++ b/ansible/roles/uv_python_service/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# Handler name uses the runtime service_name so multiple instantiations of this
+# role (one per MCP server) get distinct handlers and don't collide.
+- name: "Restart {{ service_name }}"
+  ansible.builtin.systemd_service:
+    name: "{{ service_name }}"
+    daemon_reload: yes
+    state: restarted

--- a/ansible/roles/uv_python_service/meta/main.yml
+++ b/ansible/roles/uv_python_service/meta/main.yml
@@ -1,0 +1,16 @@
+---
+galaxy_info:
+  role_name: uv_python_service
+  author: seigo
+  description: >
+    Deploy a uv-managed Python application as a systemd service with hardening
+    baked in. Used for MCP servers and similar long-lived Python daemons on the
+    hermes-agent VM.
+  license: MIT
+  min_ansible_version: "2.16"
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+
+dependencies: []

--- a/ansible/roles/uv_python_service/tasks/main.yml
+++ b/ansible/roles/uv_python_service/tasks/main.yml
@@ -1,0 +1,132 @@
+---
+# Implements the 8 steps documented in docs/standards/ansible-role-boundaries.md
+# (in hermes-agent repo). Idempotent: re-running is a no-op when nothing changed.
+
+- name: "[{{ service_name }}] Validate required role arguments"
+  ansible.builtin.assert:
+    that:
+      - service_name is defined and service_name | length > 0
+      - service_user is defined and service_user | length > 0
+      - service_home is defined and service_home | length > 0
+      - git_repo is defined and git_repo | length > 0
+      - git_version is defined and git_version | length > 0
+      - exec_start is defined and exec_start | length > 0
+      - read_write_paths is defined and read_write_paths | length > 0
+    fail_msg: >-
+      uv_python_service requires service_name, service_user, service_home,
+      git_repo, git_version, exec_start, read_write_paths to be set.
+
+- name: "[{{ service_name }}] Create service user (system account, no shell)"
+  ansible.builtin.user:
+    name: "{{ service_user }}"
+    home: "{{ service_home }}"
+    shell: /usr/sbin/nologin
+    system: yes
+    create_home: yes
+
+- name: "[{{ service_name }}] Download uv installer"
+  ansible.builtin.get_url:
+    url: https://astral.sh/uv/install.sh
+    dest: "/tmp/uv-install-{{ service_name }}.sh"
+    mode: "0700"
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
+
+- name: "[{{ service_name }}] Install uv under service user"
+  ansible.builtin.command: "/bin/sh /tmp/uv-install-{{ service_name }}.sh"
+  args:
+    creates: "{{ service_uv_bin }}"
+  become_user: "{{ service_user }}"
+  environment:
+    HOME: "{{ service_home }}"
+    UV_INSTALL_DIR: "{{ service_uv_install_dir }}"
+    UV_UNMANAGED_INSTALL: "{{ service_uv_install_dir }}"
+
+- name: "[{{ service_name }}] Clone upstream source"
+  ansible.builtin.git:
+    repo: "{{ git_repo }}"
+    dest: "{{ service_app_dir }}"
+    version: "{{ git_version }}"
+    # Pinned to a tag/SHA per docs/standards/upstream-pinning.md, so update is allowed
+    # only when caller bumps git_version explicitly.
+  become_user: "{{ service_user }}"
+
+- name: "[{{ service_name }}] Create virtualenv with Python {{ python_version }} via uv"
+  ansible.builtin.command: "{{ service_uv_bin }} venv venv --python {{ python_version }}"
+  args:
+    chdir: "{{ service_app_dir }}"
+    creates: "{{ service_venv_dir }}/bin/python"
+  become_user: "{{ service_user }}"
+  environment:
+    HOME: "{{ service_home }}"
+
+- name: "[{{ service_name }}] Install application via uv pip"
+  ansible.builtin.command: "{{ install_command }}"
+  args:
+    chdir: "{{ service_app_dir }}"
+  become_user: "{{ service_user }}"
+  environment:
+    HOME: "{{ service_home }}"
+    VIRTUAL_ENV: "{{ service_venv_dir }}"
+    PATH: "{{ service_uv_install_dir }}:{{ ansible_env.PATH }}"
+  # We don't have a reliable `creates:` marker (the binary name varies per app),
+  # so this runs every play. uv pip install is idempotent when nothing changed.
+  changed_when: false
+  register: uv_pip_install_result
+  failed_when:
+    - uv_pip_install_result.rc != 0
+
+- name: "[{{ service_name }}] Ensure state_dir exists"
+  ansible.builtin.file:
+    path: "{{ state_dir }}"
+    state: directory
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
+    mode: "0700"
+  when: state_dir | length > 0
+
+- name: "[{{ service_name }}] Ensure env directory exists"
+  ansible.builtin.file:
+    path: "{{ env_dir }}"
+    state: directory
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
+    mode: "0750"
+
+- name: "[{{ service_name }}] Check if env file already exists"
+  ansible.builtin.stat:
+    path: "{{ service_env_file }}"
+  register: service_env_stat
+
+# TODO: replace this stanza with SOPS-decrypted template once
+# docs/standards/secrets-management.md is implemented (community.sops collection).
+# For now, callers populate /etc/<service>/.env manually after first deploy.
+- name: "[{{ service_name }}] Create empty env file if missing"
+  ansible.builtin.copy:
+    content: ""
+    dest: "{{ service_env_file }}"
+    owner: "{{ service_user }}"
+    group: "{{ service_user }}"
+    mode: "0600"
+    force: no
+  when: not service_env_stat.stat.exists
+
+- name: "[{{ service_name }}] Install systemd unit"
+  ansible.builtin.template:
+    src: systemd.service.j2
+    dest: "/etc/systemd/system/{{ service_name }}.service"
+    mode: "0644"
+  notify: "Restart {{ service_name }}"
+
+- name: "[{{ service_name }}] Enable and start service"
+  ansible.builtin.systemd_service:
+    name: "{{ service_name }}"
+    daemon_reload: yes
+    enabled: yes
+    state: started
+
+- name: "[{{ service_name }}] Verify service is active"
+  ansible.builtin.command: "systemctl is-active {{ service_name }}"
+  register: service_active
+  changed_when: false
+  failed_when: service_active.stdout != "active"

--- a/ansible/roles/uv_python_service/templates/systemd.service.j2
+++ b/ansible/roles/uv_python_service/templates/systemd.service.j2
@@ -1,0 +1,52 @@
+[Unit]
+Description={{ service_description }}
+{% for t in after_targets %}
+After={{ t }}
+{% endfor %}
+{% for t in wants_targets %}
+Wants={{ t }}
+{% endfor %}
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
+[Service]
+Type=simple
+User={{ service_user }}
+Group={{ service_user }}
+WorkingDirectory={{ service_app_dir }}
+Environment=HOME={{ service_home }}
+{% for k, v in extra_environment.items() %}
+Environment={{ k }}={{ v }}
+{% endfor %}
+EnvironmentFile={{ service_env_file }}
+ExecStart={{ exec_start }}
+Restart={{ restart_policy }}
+RestartSec={{ restart_sec }}
+
+# --- Hardening: baseline (docs/standards/systemd-hardening.md) ---
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=tmpfs
+PrivateTmp=true
+ReadWritePaths={{ read_write_paths | join(' ') }}
+
+{% if hardening_profile == 'python-mcp-server' %}
+# --- Hardening: python-mcp-server profile additions ---
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictSUIDSGID=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+RestrictRealtime=true
+RestrictNamespaces=true
+SystemCallFilter=@system-service
+SystemCallArchitectures=native
+{% endif %}
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/setup-hermes.yml
+++ b/ansible/setup-hermes.yml
@@ -31,6 +31,7 @@
           - build-essential
           - libssl-dev
           - libffi-dev
+          - acl
         state: present
         update_cache: yes
 
@@ -88,8 +89,11 @@
       environment:
         HOME: "{{ hermes_home }}"
 
-    - name: Sync dependencies from uv.lock (upstream preferred)
-      ansible.builtin.command: "{{ uv_bin }} sync --all-extras --locked"
+    # Mirror upstream scripts/install.sh: try full extras, fall back to base install.
+    # `uv pip install -e ".[all]"` is used instead of `uv sync` because upstream does
+    # not maintain uv.lock in lockstep with pyproject.toml (verified on main @ 2026-04).
+    - name: Install hermes-agent with all extras
+      ansible.builtin.command: '{{ uv_bin }} pip install -e ".[all]"'
       args:
         chdir: "{{ hermes_app_dir }}"
         creates: "{{ hermes_venv_dir }}/bin/hermes-agent"
@@ -97,6 +101,22 @@
       environment:
         HOME: "{{ hermes_home }}"
         VIRTUAL_ENV: "{{ hermes_venv_dir }}"
+      register: hermes_install_all
+      failed_when:
+        - hermes_install_all.rc != 0
+        - '"Could not find a version that satisfies" not in hermes_install_all.stderr'
+        - '"No matching distribution" not in hermes_install_all.stderr'
+        - '"Failed to build" not in hermes_install_all.stderr'
+
+    - name: Fallback - install hermes-agent base only if extras failed
+      ansible.builtin.command: '{{ uv_bin }} pip install -e "."'
+      args:
+        chdir: "{{ hermes_app_dir }}"
+      become_user: "{{ hermes_user }}"
+      environment:
+        HOME: "{{ hermes_home }}"
+        VIRTUAL_ENV: "{{ hermes_venv_dir }}"
+      when: hermes_install_all.rc is defined and hermes_install_all.rc != 0
 
     - name: Ensure env directory exists
       ansible.builtin.file:
@@ -133,6 +153,8 @@
           Description=Hermes Agent (NousResearch)
           After=network-online.target
           Wants=network-online.target
+          StartLimitIntervalSec=120
+          StartLimitBurst=5
 
           [Service]
           Type=simple
@@ -144,8 +166,6 @@
           ExecStart={{ hermes_venv_dir }}/bin/hermes-agent
           Restart=on-failure
           RestartSec=10
-          StartLimitIntervalSec=120
-          StartLimitBurst=5
           NoNewPrivileges=true
           ProtectSystem=strict
           ProtectHome=tmpfs

--- a/ansible/setup-hermes.yml
+++ b/ansible/setup-hermes.yml
@@ -1,4 +1,8 @@
 ---
+# OS baseline (timezone / NTP / unattended-upgrades / common apt + Python 3.11 assert)
+# is shared with setup-mcp-servers.yml. See base.yml.
+- import_playbook: base.yml
+
 - name: Provision Hermes Agent on standalone VM
   hosts: hermes-agent
   remote_user: debian
@@ -12,12 +16,12 @@
     hermes_env_dir: /etc/hermes-agent
     hermes_env_file: "{{ hermes_env_dir }}/.env"
     # TODO: pin to a specific tag or SHA once upstream cuts releases
+    # See docs/standards/upstream-pinning.md (in hermes-agent repo).
     hermes_git_repo: https://github.com/NousResearch/hermes-agent.git
     hermes_git_version: main
     hermes_python_version: "3.11"
     uv_install_dir: "{{ hermes_home }}/.local/bin"
     uv_bin: "{{ uv_install_dir }}/uv"
-    system_timezone: Asia/Tokyo
     # Grants the hermes service user access to the Docker daemon so the
     # upstream Docker tool backend can run containers for agent sessions.
     # WARNING: docker group membership is effectively root on the host; the
@@ -25,40 +29,7 @@
     hermes_docker_access: true
 
   tasks:
-    # ----- OS baseline (timezone / NTP / auto security updates / Docker) -----
-    - name: Read current timezone
-      ansible.builtin.command: timedatectl show -p Timezone --value
-      register: current_timezone
-      changed_when: false
-
-    - name: Set system timezone
-      ansible.builtin.command: "timedatectl set-timezone {{ system_timezone }}"
-      when: current_timezone.stdout != system_timezone
-
-    - name: Ensure systemd-timesyncd (NTP) is enabled and running
-      ansible.builtin.systemd_service:
-        name: systemd-timesyncd
-        enabled: yes
-        state: started
-
-    - name: Install unattended-upgrades
-      ansible.builtin.apt:
-        name:
-          - unattended-upgrades
-          - apt-listchanges
-        state: present
-        update_cache: yes
-
-    - name: Enable automatic package list refresh and security upgrades
-      ansible.builtin.copy:
-        dest: /etc/apt/apt.conf.d/20auto-upgrades
-        mode: "0644"
-        content: |
-          APT::Periodic::Update-Package-Lists "1";
-          APT::Periodic::Unattended-Upgrade "1";
-          APT::Periodic::AutocleanInterval "7";
-      notify: Reload unattended-upgrades
-
+    # ----- Docker (Hermes-only need: Docker tool backend for agent sessions) -----
     - name: Ensure /etc/apt/keyrings exists
       ansible.builtin.file:
         path: /etc/apt/keyrings
@@ -100,34 +71,7 @@
         enabled: yes
         state: started
 
-    # ----- Hermes-specific packages -----
-    - name: Install base packages
-      ansible.builtin.apt:
-        name:
-          - python3
-          - python3-venv
-          - python3-dev
-          - git
-          - curl
-          - ca-certificates
-          - build-essential
-          - libssl-dev
-          - libffi-dev
-          - acl
-        state: present
-        update_cache: yes
-
-    - name: Check python3 version
-      ansible.builtin.command: python3 --version
-      register: python_version_check
-      changed_when: false
-
-    - name: Assert python3 is 3.11 (required by hermes-agent upstream)
-      ansible.builtin.assert:
-        that:
-          - python_version_check.stdout is match('^Python 3\\.11(\\.|$)')
-        fail_msg: "Expected Python 3.11 (upstream install.sh hardcodes 3.11), got: {{ python_version_check.stdout }}"
-
+    # ----- Hermes Agent install -----
     - name: Create hermes service user (system account, no interactive shell)
       ansible.builtin.user:
         name: "{{ hermes_user }}"
@@ -230,8 +174,9 @@
         mode: "0600"
         force: no
       when: not hermes_env_stat.stat.exists
-      # TODO: migrate secrets to ansible-vault or SOPS for multi-user ops.
-      # Operators populate keys with `hermes setup` / `hermes config set` or by editing this file.
+      # TODO: migrate secrets to SOPS+age (see docs/standards/secrets-management.md
+      # in hermes-agent repo). Operators currently populate keys with
+      # `hermes setup` / `hermes config set` or by editing this file.
 
     - name: Install hermes-agent systemd unit
       ansible.builtin.copy:
@@ -283,11 +228,6 @@
       ansible.builtin.systemd_service:
         name: hermes-agent
         daemon_reload: yes
-        state: restarted
-
-    - name: Reload unattended-upgrades
-      ansible.builtin.systemd_service:
-        name: unattended-upgrades
         state: restarted
 
     - name: Refresh apt cache

--- a/ansible/setup-hermes.yml
+++ b/ansible/setup-hermes.yml
@@ -18,9 +18,11 @@
     uv_install_dir: "{{ hermes_home }}/.local/bin"
     uv_bin: "{{ uv_install_dir }}/uv"
     system_timezone: Asia/Tokyo
-    # Set to true to let the hermes service user control the Docker daemon.
-    # WARNING: docker group membership is effectively root on the host.
-    hermes_docker_access: false
+    # Grants the hermes service user access to the Docker daemon so the
+    # upstream Docker tool backend can run containers for agent sessions.
+    # WARNING: docker group membership is effectively root on the host; the
+    # blast radius of a compromised hermes process is the whole VM.
+    hermes_docker_access: true
 
   tasks:
     # ----- OS baseline (timezone / NTP / auto security updates / Docker) -----

--- a/ansible/setup-hermes.yml
+++ b/ansible/setup-hermes.yml
@@ -1,0 +1,168 @@
+---
+- name: Provision Hermes Agent on standalone VM
+  hosts: hermes-agent
+  remote_user: debian
+  become: yes
+
+  vars:
+    hermes_user: hermes
+    hermes_home: /opt/hermes-agent
+    hermes_app_dir: "{{ hermes_home }}/app"
+    hermes_venv_dir: "{{ hermes_app_dir }}/venv"
+    hermes_env_dir: /etc/hermes-agent
+    hermes_env_file: "{{ hermes_env_dir }}/.env"
+    # TODO: pin to a specific tag or SHA once upstream cuts releases
+    hermes_git_repo: https://github.com/NousResearch/hermes-agent.git
+    hermes_git_version: main
+    hermes_python_version: "3.11"
+    uv_bin: "{{ hermes_home }}/.local/bin/uv"
+    # Provide via --extra-vars or (future) ansible-vault.
+    # TODO: migrate secrets to ansible-vault or SOPS for multi-user ops.
+    openrouter_api_key: ""
+    anthropic_api_key: ""
+    openai_api_key: ""
+    elevenlabs_api_key: ""
+
+  tasks:
+    - name: Install base packages
+      ansible.builtin.apt:
+        name:
+          - python3
+          - python3-venv
+          - git
+          - curl
+          - ca-certificates
+          - build-essential
+        state: present
+        update_cache: yes
+
+    - name: Check python3 version
+      ansible.builtin.command: python3 --version
+      register: python_version_check
+      changed_when: false
+
+    - name: Assert python3 is 3.11 (required by hermes-agent upstream)
+      ansible.builtin.assert:
+        that:
+          - python_version_check.stdout is match('^Python 3\\.11(\\.|$)')
+        fail_msg: "Expected Python 3.11 (upstream install.sh hardcodes 3.11), got: {{ python_version_check.stdout }}"
+
+    - name: Create hermes service user
+      ansible.builtin.user:
+        name: "{{ hermes_user }}"
+        home: "{{ hermes_home }}"
+        shell: /bin/bash
+        system: yes
+        create_home: yes
+
+    - name: Download uv installer
+      ansible.builtin.get_url:
+        url: https://astral.sh/uv/install.sh
+        dest: /tmp/uv-install.sh
+        mode: "0700"
+        owner: "{{ hermes_user }}"
+        group: "{{ hermes_user }}"
+
+    - name: Install uv under hermes user
+      ansible.builtin.command: /bin/sh /tmp/uv-install.sh
+      args:
+        creates: "{{ uv_bin }}"
+      become_user: "{{ hermes_user }}"
+      environment:
+        HOME: "{{ hermes_home }}"
+
+    - name: Clone hermes-agent source
+      ansible.builtin.git:
+        repo: "{{ hermes_git_repo }}"
+        dest: "{{ hermes_app_dir }}"
+        version: "{{ hermes_git_version }}"
+      become_user: "{{ hermes_user }}"
+
+    - name: Create virtualenv with Python 3.11 via uv
+      ansible.builtin.command: "{{ uv_bin }} venv venv --python {{ hermes_python_version }}"
+      args:
+        chdir: "{{ hermes_app_dir }}"
+        creates: "{{ hermes_venv_dir }}/bin/python"
+      become_user: "{{ hermes_user }}"
+      environment:
+        HOME: "{{ hermes_home }}"
+
+    - name: Install hermes-agent into virtualenv
+      ansible.builtin.command: "{{ uv_bin }} pip install -e .[all]"
+      args:
+        chdir: "{{ hermes_app_dir }}"
+        creates: "{{ hermes_venv_dir }}/bin/hermes"
+      become_user: "{{ hermes_user }}"
+      environment:
+        HOME: "{{ hermes_home }}"
+        VIRTUAL_ENV: "{{ hermes_venv_dir }}"
+
+    - name: Ensure env directory exists
+      ansible.builtin.file:
+        path: "{{ hermes_env_dir }}"
+        state: directory
+        owner: "{{ hermes_user }}"
+        group: "{{ hermes_user }}"
+        mode: "0750"
+
+    - name: Deploy environment file
+      ansible.builtin.copy:
+        dest: "{{ hermes_env_file }}"
+        owner: "{{ hermes_user }}"
+        group: "{{ hermes_user }}"
+        mode: "0600"
+        content: |
+          OPENROUTER_API_KEY={{ openrouter_api_key }}
+          ANTHROPIC_API_KEY={{ anthropic_api_key }}
+          OPENAI_API_KEY={{ openai_api_key }}
+          ELEVENLABS_API_KEY={{ elevenlabs_api_key }}
+      notify: Restart hermes-agent
+
+    - name: Install hermes-agent systemd unit
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/hermes-agent.service
+        mode: "0644"
+        content: |
+          [Unit]
+          Description=Hermes Agent (NousResearch)
+          After=network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Type=simple
+          User={{ hermes_user }}
+          Group={{ hermes_user }}
+          WorkingDirectory={{ hermes_app_dir }}
+          EnvironmentFile={{ hermes_env_file }}
+          ExecStart={{ hermes_venv_dir }}/bin/hermes run
+          Restart=on-failure
+          RestartSec=10
+          NoNewPrivileges=true
+          ProtectSystem=strict
+          ProtectHome=true
+          PrivateTmp=true
+          ReadWritePaths={{ hermes_home }}
+
+          [Install]
+          WantedBy=multi-user.target
+      notify: Restart hermes-agent
+
+    - name: Enable and start hermes-agent
+      ansible.builtin.systemd:
+        name: hermes-agent
+        daemon_reload: yes
+        enabled: yes
+        state: started
+
+    - name: Verify hermes-agent is active
+      ansible.builtin.command: systemctl is-active hermes-agent
+      register: hermes_active
+      changed_when: false
+      failed_when: hermes_active.stdout != "active"
+
+  handlers:
+    - name: Restart hermes-agent
+      ansible.builtin.systemd:
+        name: hermes-agent
+        daemon_reload: yes
+        state: restarted

--- a/ansible/setup-hermes.yml
+++ b/ansible/setup-hermes.yml
@@ -15,13 +15,8 @@
     hermes_git_repo: https://github.com/NousResearch/hermes-agent.git
     hermes_git_version: main
     hermes_python_version: "3.11"
-    uv_bin: "{{ hermes_home }}/.local/bin/uv"
-    # Provide via --extra-vars or (future) ansible-vault.
-    # TODO: migrate secrets to ansible-vault or SOPS for multi-user ops.
-    openrouter_api_key: ""
-    anthropic_api_key: ""
-    openai_api_key: ""
-    elevenlabs_api_key: ""
+    uv_install_dir: "{{ hermes_home }}/.local/bin"
+    uv_bin: "{{ uv_install_dir }}/uv"
 
   tasks:
     - name: Install base packages
@@ -29,10 +24,13 @@
         name:
           - python3
           - python3-venv
+          - python3-dev
           - git
           - curl
           - ca-certificates
           - build-essential
+          - libssl-dev
+          - libffi-dev
         state: present
         update_cache: yes
 
@@ -70,12 +68,15 @@
       become_user: "{{ hermes_user }}"
       environment:
         HOME: "{{ hermes_home }}"
+        UV_INSTALL_DIR: "{{ uv_install_dir }}"
+        UV_UNMANAGED_INSTALL: "{{ uv_install_dir }}"
 
     - name: Clone hermes-agent source
       ansible.builtin.git:
         repo: "{{ hermes_git_repo }}"
         dest: "{{ hermes_app_dir }}"
         version: "{{ hermes_git_version }}"
+        # TODO: set update: no once pinned to a release tag / SHA
       become_user: "{{ hermes_user }}"
 
     - name: Create virtualenv with Python 3.11 via uv
@@ -87,11 +88,11 @@
       environment:
         HOME: "{{ hermes_home }}"
 
-    - name: Install hermes-agent into virtualenv
-      ansible.builtin.command: "{{ uv_bin }} pip install -e .[all]"
+    - name: Sync dependencies from uv.lock (upstream preferred)
+      ansible.builtin.command: "{{ uv_bin }} sync --all-extras --locked"
       args:
         chdir: "{{ hermes_app_dir }}"
-        creates: "{{ hermes_venv_dir }}/bin/hermes"
+        creates: "{{ hermes_venv_dir }}/bin/hermes-agent"
       become_user: "{{ hermes_user }}"
       environment:
         HOME: "{{ hermes_home }}"
@@ -105,18 +106,23 @@
         group: "{{ hermes_user }}"
         mode: "0750"
 
-    - name: Deploy environment file
+    - name: Check if env file already exists
+      ansible.builtin.stat:
+        path: "{{ hermes_env_file }}"
+      register: hermes_env_stat
+
+    - name: Seed env file from upstream .env.example (only if missing)
       ansible.builtin.copy:
+        src: "{{ hermes_app_dir }}/.env.example"
         dest: "{{ hermes_env_file }}"
+        remote_src: yes
         owner: "{{ hermes_user }}"
         group: "{{ hermes_user }}"
         mode: "0600"
-        content: |
-          OPENROUTER_API_KEY={{ openrouter_api_key }}
-          ANTHROPIC_API_KEY={{ anthropic_api_key }}
-          OPENAI_API_KEY={{ openai_api_key }}
-          ELEVENLABS_API_KEY={{ elevenlabs_api_key }}
-      notify: Restart hermes-agent
+        force: no
+      when: not hermes_env_stat.stat.exists
+      # TODO: migrate secrets to ansible-vault or SOPS for multi-user ops.
+      # Operators populate keys with `hermes setup` / `hermes config set` or by editing this file.
 
     - name: Install hermes-agent systemd unit
       ansible.builtin.copy:
@@ -133,13 +139,16 @@
           User={{ hermes_user }}
           Group={{ hermes_user }}
           WorkingDirectory={{ hermes_app_dir }}
+          Environment=HOME={{ hermes_home }}
           EnvironmentFile={{ hermes_env_file }}
-          ExecStart={{ hermes_venv_dir }}/bin/hermes run
+          ExecStart={{ hermes_venv_dir }}/bin/hermes-agent
           Restart=on-failure
           RestartSec=10
+          StartLimitIntervalSec=120
+          StartLimitBurst=5
           NoNewPrivileges=true
           ProtectSystem=strict
-          ProtectHome=true
+          ProtectHome=tmpfs
           PrivateTmp=true
           ReadWritePaths={{ hermes_home }}
 
@@ -148,7 +157,7 @@
       notify: Restart hermes-agent
 
     - name: Enable and start hermes-agent
-      ansible.builtin.systemd:
+      ansible.builtin.systemd_service:
         name: hermes-agent
         daemon_reload: yes
         enabled: yes
@@ -162,7 +171,7 @@
 
   handlers:
     - name: Restart hermes-agent
-      ansible.builtin.systemd:
+      ansible.builtin.systemd_service:
         name: hermes-agent
         daemon_reload: yes
         state: restarted

--- a/ansible/setup-hermes.yml
+++ b/ansible/setup-hermes.yml
@@ -17,8 +17,88 @@
     hermes_python_version: "3.11"
     uv_install_dir: "{{ hermes_home }}/.local/bin"
     uv_bin: "{{ uv_install_dir }}/uv"
+    system_timezone: Asia/Tokyo
+    # Set to true to let the hermes service user control the Docker daemon.
+    # WARNING: docker group membership is effectively root on the host.
+    hermes_docker_access: false
 
   tasks:
+    # ----- OS baseline (timezone / NTP / auto security updates / Docker) -----
+    - name: Read current timezone
+      ansible.builtin.command: timedatectl show -p Timezone --value
+      register: current_timezone
+      changed_when: false
+
+    - name: Set system timezone
+      ansible.builtin.command: "timedatectl set-timezone {{ system_timezone }}"
+      when: current_timezone.stdout != system_timezone
+
+    - name: Ensure systemd-timesyncd (NTP) is enabled and running
+      ansible.builtin.systemd_service:
+        name: systemd-timesyncd
+        enabled: yes
+        state: started
+
+    - name: Install unattended-upgrades
+      ansible.builtin.apt:
+        name:
+          - unattended-upgrades
+          - apt-listchanges
+        state: present
+        update_cache: yes
+
+    - name: Enable automatic package list refresh and security upgrades
+      ansible.builtin.copy:
+        dest: /etc/apt/apt.conf.d/20auto-upgrades
+        mode: "0644"
+        content: |
+          APT::Periodic::Update-Package-Lists "1";
+          APT::Periodic::Unattended-Upgrade "1";
+          APT::Periodic::AutocleanInterval "7";
+      notify: Reload unattended-upgrades
+
+    - name: Ensure /etc/apt/keyrings exists
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: "0755"
+
+    - name: Add Docker official GPG key
+      ansible.builtin.get_url:
+        url: https://download.docker.com/linux/debian/gpg
+        dest: /etc/apt/keyrings/docker.asc
+        mode: "0644"
+        force: no
+
+    - name: Add Docker apt repository
+      ansible.builtin.copy:
+        dest: /etc/apt/sources.list.d/docker.list
+        mode: "0644"
+        content: |
+          deb [arch={{ ansible_architecture | replace('x86_64', 'amd64') | replace('aarch64', 'arm64') }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian {{ ansible_distribution_release }} stable
+      notify: Refresh apt cache
+
+    - name: Flush apt cache refresh before installing Docker
+      ansible.builtin.meta: flush_handlers
+
+    - name: Install Docker Engine and Compose plugin
+      ansible.builtin.apt:
+        name:
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
+          - docker-buildx-plugin
+          - docker-compose-plugin
+        state: present
+        update_cache: yes
+
+    - name: Ensure Docker daemon is enabled and running
+      ansible.builtin.systemd_service:
+        name: docker
+        enabled: yes
+        state: started
+
+    # ----- Hermes-specific packages -----
     - name: Install base packages
       ansible.builtin.apt:
         name:
@@ -46,13 +126,20 @@
           - python_version_check.stdout is match('^Python 3\\.11(\\.|$)')
         fail_msg: "Expected Python 3.11 (upstream install.sh hardcodes 3.11), got: {{ python_version_check.stdout }}"
 
-    - name: Create hermes service user
+    - name: Create hermes service user (system account, no interactive shell)
       ansible.builtin.user:
         name: "{{ hermes_user }}"
         home: "{{ hermes_home }}"
-        shell: /bin/bash
+        shell: /usr/sbin/nologin
         system: yes
         create_home: yes
+
+    - name: Grant hermes access to Docker socket (opt-in)
+      ansible.builtin.user:
+        name: "{{ hermes_user }}"
+        groups: docker
+        append: yes
+      when: hermes_docker_access | bool
 
     - name: Download uv installer
       ansible.builtin.get_url:
@@ -195,3 +282,12 @@
         name: hermes-agent
         daemon_reload: yes
         state: restarted
+
+    - name: Reload unattended-upgrades
+      ansible.builtin.systemd_service:
+        name: unattended-upgrades
+        state: restarted
+
+    - name: Refresh apt cache
+      ansible.builtin.apt:
+        update_cache: yes

--- a/ansible/setup-mcp-servers.yml
+++ b/ansible/setup-mcp-servers.yml
@@ -1,0 +1,58 @@
+---
+# Provision MCP servers on the hermes-agent VM.
+# Each entry in mcp_servers gets the uv_python_service role applied.
+# Adding a new MCP server = appending one item to the mcp_servers list and
+# allocating a port from docs/standards/port-allocation.md.
+
+- import_playbook: base.yml
+
+- name: Provision MCP servers on hermes-agent VM
+  hosts: hermes-agent
+  remote_user: debian
+  become: yes
+
+  vars:
+    mcp_servers:
+      - name: google-workspace-mcp
+        user: gwmcp
+        home: /opt/google-workspace-mcp
+        git_repo: https://github.com/taylorwilsdon/google_workspace_mcp.git
+        git_version: v1.20.0
+        port: 8080
+        # Per docs/plans/google-integration.md: HTTP transport, calendar+tasks only,
+        # listen on 127.0.0.1 only. Path-quoting via {{ }} is intentional — those
+        # are computed-at-role-time variables, not Ansible host vars.
+        exec_start: >-
+          /opt/google-workspace-mcp/app/venv/bin/python
+          /opt/google-workspace-mcp/app/main.py
+          --transport streamable-http
+          --tools calendar tasks
+        read_write_paths:
+          - /opt/google-workspace-mcp
+          - /var/lib/google-workspace-mcp
+        # WORKSPACE_MCP_HOST/PORT are read from this Environment, NOT from the
+        # CLI — upstream README provides only env vars for host/port.
+        # GOOGLE_MCP_CREDENTIALS_DIR moves OAuth tokens out of the service home
+        # so they live under /var/lib/ per Linux convention.
+        extra_environment:
+          WORKSPACE_MCP_HOST: "127.0.0.1"
+          WORKSPACE_MCP_PORT: "8080"
+          GOOGLE_MCP_CREDENTIALS_DIR: "/var/lib/google-workspace-mcp/credentials"
+
+  tasks:
+    - name: Deploy each MCP server via uv_python_service role
+      ansible.builtin.include_role:
+        name: uv_python_service
+      vars:
+        service_name: "{{ item.name }}"
+        service_user: "{{ item.user }}"
+        service_home: "{{ item.home }}"
+        git_repo: "{{ item.git_repo }}"
+        git_version: "{{ item.git_version }}"
+        exec_start: "{{ item.exec_start }}"
+        read_write_paths: "{{ item.read_write_paths }}"
+        extra_environment: "{{ item.extra_environment | default({}) }}"
+        service_description: "{{ item.name }} (MCP server)"
+      loop: "{{ mcp_servers }}"
+      loop_control:
+        label: "{{ item.name }}"

--- a/terraform/modules/hermes-agent/main.tf
+++ b/terraform/modules/hermes-agent/main.tf
@@ -1,0 +1,62 @@
+# Hermes Agent module - standalone VM for NousResearch/hermes-agent
+
+terraform {
+  required_providers {
+    proxmox = {
+      source  = "Telmate/proxmox"
+      version = "3.0.1-rc9"
+    }
+  }
+}
+
+resource "proxmox_vm_qemu" "hermes_agent" {
+  name        = var.vm_name
+  target_node = var.proxmox_node
+  clone       = var.template_vm_base
+  full_clone  = true
+  os_type     = "cloud-init"
+
+  cpu {
+    cores   = var.cores
+    sockets = var.sockets
+  }
+
+  memory   = var.memory
+  agent    = 1
+  onboot   = true
+  scsihw   = "virtio-scsi-pci"
+  bootdisk = "scsi0"
+
+  disks {
+    scsi {
+      scsi0 {
+        disk {
+          size       = var.disk_size
+          storage    = var.storage_pool
+          emulatessd = true
+        }
+      }
+    }
+    ide {
+      ide2 {
+        cloudinit {
+          storage = var.storage_pool
+        }
+      }
+    }
+  }
+
+  serial {
+    id   = 0
+    type = "socket"
+  }
+
+  network {
+    id     = 0
+    model  = "virtio"
+    bridge = var.network_bridge
+  }
+
+  sshkeys   = var.ssh_public_key
+  ipconfig0 = "ip=${var.ip_address}/${var.network_prefix},gw=${var.gateway}"
+}

--- a/terraform/modules/hermes-agent/outputs.tf
+++ b/terraform/modules/hermes-agent/outputs.tf
@@ -1,0 +1,16 @@
+# Hermes Agent module outputs
+
+output "ip" {
+  description = "IP address of the Hermes Agent VM"
+  value       = var.ip_address
+}
+
+output "vm_name" {
+  description = "Name of the Hermes Agent VM"
+  value       = proxmox_vm_qemu.hermes_agent.name
+}
+
+output "vm_id" {
+  description = "ID of the Hermes Agent VM"
+  value       = proxmox_vm_qemu.hermes_agent.id
+}

--- a/terraform/modules/hermes-agent/variables.tf
+++ b/terraform/modules/hermes-agent/variables.tf
@@ -1,0 +1,68 @@
+# Hermes Agent module variables
+
+variable "proxmox_node" {
+  description = "Proxmox node to deploy VM on"
+  default     = "pve"
+}
+
+variable "template_vm_base" {
+  description = "Base VM template name to clone from"
+  default     = "Debian12CloudInit"
+}
+
+variable "storage_pool" {
+  description = "Storage pool to use for VM disks"
+  default     = "local-zfs"
+}
+
+variable "network_bridge" {
+  description = "Network bridge to connect VM to"
+  default     = "vmbr0"
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key for VM access"
+  type        = string
+}
+
+# Network settings
+variable "ip_address" {
+  description = "IP address for the Hermes Agent VM"
+  type        = string
+}
+
+variable "network_prefix" {
+  description = "Network prefix (CIDR notation)"
+  default     = "24"
+}
+
+variable "gateway" {
+  description = "Network gateway address"
+  type        = string
+}
+
+# VM spec
+variable "vm_name" {
+  description = "Name for the Hermes Agent VM"
+  default     = "hermes-agent"
+}
+
+variable "cores" {
+  description = "CPU cores for the Hermes Agent VM"
+  default     = 2
+}
+
+variable "sockets" {
+  description = "CPU sockets for the Hermes Agent VM"
+  default     = 1
+}
+
+variable "memory" {
+  description = "Memory in MB for the Hermes Agent VM"
+  default     = 4096
+}
+
+variable "disk_size" {
+  description = "Disk size in GB for the Hermes Agent VM"
+  default     = 20
+}

--- a/terraform/modules/hermes-agent/variables.tf
+++ b/terraform/modules/hermes-agent/variables.tf
@@ -2,21 +2,25 @@
 
 variable "proxmox_node" {
   description = "Proxmox node to deploy VM on"
+  type        = string
   default     = "pve"
 }
 
 variable "template_vm_base" {
   description = "Base VM template name to clone from"
+  type        = string
   default     = "Debian12CloudInit"
 }
 
 variable "storage_pool" {
   description = "Storage pool to use for VM disks"
+  type        = string
   default     = "local-zfs"
 }
 
 variable "network_bridge" {
   description = "Network bridge to connect VM to"
+  type        = string
   default     = "vmbr0"
 }
 
@@ -33,6 +37,7 @@ variable "ip_address" {
 
 variable "network_prefix" {
   description = "Network prefix (CIDR notation)"
+  type        = string
   default     = "24"
 }
 
@@ -44,25 +49,40 @@ variable "gateway" {
 # VM spec
 variable "vm_name" {
   description = "Name for the Hermes Agent VM"
+  type        = string
   default     = "hermes-agent"
 }
 
 variable "cores" {
   description = "CPU cores for the Hermes Agent VM"
+  type        = number
   default     = 2
+
+  validation {
+    condition     = var.cores > 0
+    error_message = "cores must be greater than 0"
+  }
 }
 
 variable "sockets" {
   description = "CPU sockets for the Hermes Agent VM"
+  type        = number
   default     = 1
 }
 
 variable "memory" {
   description = "Memory in MB for the Hermes Agent VM"
+  type        = number
   default     = 4096
+
+  validation {
+    condition     = var.memory >= 512
+    error_message = "memory must be at least 512 MB"
+  }
 }
 
 variable "disk_size" {
-  description = "Disk size in GB for the Hermes Agent VM"
-  default     = 20
+  description = "Disk size for the Hermes Agent VM (Proxmox v3 format: 'K', 'M', 'G', 'T' units)"
+  type        = string
+  default     = "20G"
 }

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -47,4 +47,9 @@ module "hermes_agent" {
   ip_address     = var.hermes_agent_ip
   network_prefix = var.network_prefix
   gateway        = var.gateway
+
+  # VM spec (override module defaults for prod workload)
+  cores     = 8
+  memory    = 16384
+  disk_size = "64G"
 }

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -33,3 +33,18 @@ module "kubernetes_cluster" {
   worker_cores   = 4
   worker_memory  = 8192
 }
+
+# Standalone VM for NousResearch/hermes-agent
+module "hermes_agent" {
+  source = "../modules/hermes-agent"
+
+  proxmox_node     = var.proxmox_node
+  template_vm_base = var.template_vm_base
+  storage_pool     = var.storage_pool
+  network_bridge   = var.network_bridge
+  ssh_public_key   = file(var.ssh_public_key_path)
+
+  ip_address     = var.hermes_agent_ip
+  network_prefix = var.network_prefix
+  gateway        = var.gateway
+}

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -28,7 +28,7 @@ module "kubernetes_cluster" {
   # VM spec
   master_name    = "k8s-master"
   master_cores   = 4
-  master_memory  = 8192
+  master_memory  = 16384
   worker_name_prefix = "k8s-worker"
   worker_cores   = 4
   worker_memory  = 8192

--- a/terraform/prod/variables.tf
+++ b/terraform/prod/variables.tf
@@ -66,3 +66,8 @@ variable "network_prefix" {
 variable "gateway" {
   description = "Network gateway address"
 }
+
+variable "hermes_agent_ip" {
+  description = "IP address for the Hermes Agent standalone VM"
+  type        = string
+}


### PR DESCRIPTION
## 概要

Proxmox 環境（ノード `pve`）に、[NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) を常駐させる専用の軽量 VM を 1 台新設する。k8s クラスタの state には一切手を入れない形で、モジュール分離して追加。

- Hermes Agent は外部 LLM API に推論を委譲する軽量な Python 3.11 エージェント（GPU 不要）
- 既存の `terraform/modules/kubernetes/` と同じ Terraform + Ansible パターンを踏襲
- 既存 k8s クラスタとは責務・state を完全に分離

## スペック

| 項目 | 値 | 理由 |
| --- | --- | --- |
| vCPU | 2 | upstream が「$5 VPS で動作可」と明記する軽量構成 |
| Memory | 4096 MB | 複数チャネル常駐＋音声 I/O の余裕 |
| Disk | 20G | venv + ログ。モデルは持たないので十分 |
| Template | `Debian12CloudInit` | 既存 VM と統一（Python 3.11 が標準） |
| IP | `192.168.1.110`（env var） | master(100) / worker(101-103) と非競合 |

## 変更ファイル

### 新規

- `terraform/modules/hermes-agent/{main,variables,outputs}.tf` — `proxmox_vm_qemu "hermes_agent"` を定義する新モジュール
- `ansible/setup-hermes.yml` — uv で Python 3.11 の venv を作り、upstream を clone、`uv sync --all-extras --locked` で依存を入れ、ハードニングした systemd unit で常駐させる playbook

### 追記

- `terraform/prod/main.tf` — `module "hermes_agent"` を追加
- `terraform/prod/variables.tf` — `hermes_agent_ip` を追加
- `ansible/inventory.yml` — `hermes-agent` グループを追加（既存と同じ `TF_VAR_*` env lookup 方式）
- `README.md` — 環境変数と playbook 実行コマンドを記載

## 設計上の決定事項

- **OS: Debian 12 Bookworm**: デフォルトの `python3` が 3.11 で Hermes upstream の要件と完全一致。Debian 13 だとデフォルト 3.13 で `uv python install 3.11` が別途必要になるため採用せず
- **Python 3.11**: upstream の `scripts/install.sh` が `PYTHON_VERSION="3.11"` でハードコードしており、公式サポートは 3.11 のみ。playbook でも `ansible.builtin.assert` で 3.11 を強制
- **Proxmox プロバイダ**: 既存と同じ `Telmate/proxmox 3.0.1-rc9`。`bpg/terraform-provider-proxmox` への移行は別 PR で全体一括対応する TODO
- **シークレット管理**: 初期は upstream の `.env.example` を `force: no` でシードし、運用者が `hermes setup` または直接編集で埋める。ansible-vault / SOPS 化は TODO

## セルフレビューで反映した主な修正

- `ExecStart` は upstream に存在しない `hermes run` ではなく、`pyproject.toml` の script entry `hermes-agent`（`run_agent:main`）を使用
- `.env` は独自に列挙せず upstream `.env.example` をコピー（スキーマ drift を防止）
- 依存導入は upstream 推奨の `uv sync --all-extras --locked` を優先
- systemd: `ProtectHome=tmpfs` + `Environment=HOME` で hermes ユーザの `~/.hermes` 等への書き込みを許可、`StartLimitIntervalSec` / `StartLimitBurst` で crash loop を抑制
- `ansible.builtin.systemd` → `ansible.builtin.systemd_service` にリネーム
- Terraform 変数は全て `type` 明記、`disk_size` は Proxmox v3 の size-with-unit 規約に合わせて `"20G"` の string に

## テストプラン

- [ ] `export TF_VAR_hermes_agent_ip=192.168.1.110` を設定
- [ ] `cd terraform/prod && terraform init && terraform plan` で `module.kubernetes_cluster.*` に差分がなく、`module.hermes_agent.proxmox_vm_qemu.hermes_agent` が **1 件 add のみ** であることを確認
- [ ] `terraform apply` → VM 起動
- [ ] `ssh -i ~/.ssh/id_ed25519_k8s debian@192.168.1.110 'python3 --version'` で Python 3.11 を確認
- [ ] `ansible-playbook -i ansible/inventory.yml ansible/setup-hermes.yml` 実行
- [ ] `systemctl status hermes-agent` が `active (running)` であることを確認
- [ ] `journalctl -u hermes-agent -f` で外部 API 疎通のログを確認
- [ ] API キーを `/etc/hermes-agent/.env` に設定後、チャネル経由でエコー動作を確認

## ロールバック

- Ansible 失敗時: `terraform destroy -target='module.hermes_agent.proxmox_vm_qemu.hermes_agent'` で VM のみ削除（k8s に影響なし）
- コードのみ戻す場合: 本ブランチの各コミットを `git revert` で単独ロールバック可能

## フォローアップ TODO

- `hermes_git_version` を `main` から固定 SHA / タグへ
- シークレットを ansible-vault または SOPS へ移行
- Proxmox プロバイダを `bpg/terraform-provider-proxmox` へ全体移行（別 PR）
- Debian 13 Trixie への移行（k8s クラスタも含めて別案件）

https://claude.ai/code/session_01Ds53imDrvzvEqu54AFiAj5