### PR TITLE
Fix base.yml --check regression on Python version assert

### DIFF
--- a/ansible/base.yml
+++ b/ansible/base.yml
@@ -16,6 +16,7 @@
       ansible.builtin.command: timedatectl show -p Timezone --value
       register: current_timezone
       changed_when: false
+      check_mode: false
 
     - name: Set system timezone
       ansible.builtin.command: "timedatectl set-timezone {{ system_timezone }}"
@@ -67,6 +68,7 @@
       ansible.builtin.command: python3 --version
       register: python_version_check
       changed_when: false
+      check_mode: false
 
     - name: Assert python3 matches required version
       ansible.builtin.assert:


### PR DESCRIPTION
## Summary

- Add \`check_mode: false\` to \"Read current timezone\" and \"Check python3 version\" command tasks in \`ansible/base.yml\`.
- Without this, \`ansible-playbook --check\` skips both tasks, leaving \`python_version_check.stdout\` empty, and the assertion immediately after fails with \"Expected Python 3.11, got: \" during dry-runs.

## Why

While running \`ansible-playbook --check ansible/setup-hermes.yml\` to verify no regression after extracting \`base.yml\`, the assertion failed even though the VM has Python 3.11 installed. Real (non-check) runs always worked because command tasks execute normally outside --check.

## Test plan

- [x] \`ansible-playbook --check ansible/setup-hermes.yml\` now reports \`failed=0\` (verified locally against the live hermes-agent VM)
- [x] \`ansible-playbook --check ansible/setup-mcp-servers.yml\` passes the base.yml prelude
- [x] Real run of \`ansible-playbook ansible/setup-mcp-servers.yml\` succeeded with these tasks executing as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)